### PR TITLE
Make it python 3.7 compatible

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ $bootstrap_ubuntu = <<SCRIPT
 apt update
 apt install -y software-properties-common
 add-apt-repository -y ppa:deadsnakes/ppa
-apt install -y python3.9 python3.9-venv
-ln -sf python3.9 /usr/bin/python3
+apt install -y python3.7 python3.7-venv
+ln -sf python3.7 /usr/bin/python3
 
 SCRIPT
 

--- a/mqtt2kasa/keep_alive.py
+++ b/mqtt2kasa/keep_alive.py
@@ -73,7 +73,10 @@ async def handle_main_event_mqtt_ka(
 
 
 async def handle_keep_alives(
-    kasas: dict[str, Kasa], kas: dict[str, KeepAlive], mqtt_send_q: asyncio.Queue
+    # 3.9: kasas: dict[str, Kasa], kas: dict[str, KeepAlive], mqtt_send_q: asyncio.Queue
+    kasas: dict,
+    kas: dict,
+    mqtt_send_q: asyncio.Queue,
 ):
     if not kas:
         logger.info(


### PR DESCRIPTION
Remove typing that is not supported in python 3.7:

File "/home/pi/kasa/mqtt2kasa/mqtt2kasa/keep_alive.py", line 76, in
kasas: dict[str, Kasa], kas: dict[str, KeepAlive], mqtt_send_q: asyncio.Queue
TypeError: 'type' object is not subscriptable

Fixes https://github.com/flavio-fernandes/mqtt2kasa/issues/2

Signed-off-by: Flavio Fernandes <flavio@flaviof.com>