### PR TITLE
emeter: publish key and values as topics of emeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ MQTT=192.168.1.250 && \
 **NOTE on Metering**: If metering is supported by device and `emeter_poll_interval` was provided, it will be published via topics that end with "emeter":
 
 ```
-$ mosquitto_sub -h $MQTT -t '/+/switch/emeter'
+$ mosquitto_sub -h $MQTT -t '/+/switch/emeter' -t '/+/switch/emeter/#'
 ```
 
 In order to damper endless on/off cycles, this implementation sets an 

--- a/mqtt2kasa/tests/basic_test.sh.vagrant
+++ b/mqtt2kasa/tests/basic_test.sh.vagrant
@@ -20,7 +20,7 @@ get_simulator_lines () {
 
 # restart service to trigger discovery
 sudo systemctl restart mqtt2kasa
-sleep 5
+sleep 10
 echo TEST: Check discovery
 get_log_lines 15
 grep --quiet -E 'Discovered 192\.168\.123\.201 .*thing1' ${TMP_OUTPUT} || \


### PR DESCRIPTION
Values of emeter are also published individually.

Example:
    /dehumidifier/switch/emeter : <EmeterStatus power=3.14 voltage=122.049119 current=0.1256 total=51.493>
    /dehumidifier/switch/emeter/power : 3.14          <-- new
    /dehumidifier/switch/emeter/voltage : 122.049119  <-- new
    /dehumidifier/switch/emeter/current : 0.1256      <-- new
    /dehumidifier/switch/emeter/total : 51.493        <-- new

Fixes: https://github.com/flavio-fernandes/mqtt2kasa/issues/10