### PR TITLE
add support to change brightness on supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,15 @@ Granted the config properly refers to the TP-Link devices in the network, use re
 controlling and monitoring. Example below.
 
 Controlling the devices via MQTT via publish:
+- changing the state
 ```shell script
 $ MQTT=192.168.1.250 && \
   mosquitto_pub -h $MQTT -t /kitchen/light_switch -m off
+```
+- changing brightness (if supported)
+```shell script
+$ MQTT=192.168.1.250 && \
+  mosquitto_pub -h $MQTT -t /kitchen/light_switch/brightness -m 50
 ```
 
 Subscribe to see changes to devices, regardless on how they were controlled:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,7 +52,7 @@ $test_mqtt2kasa = <<SCRIPT
     cd tplink-smarthome-simulator
     npm install
     # Add secondary ips to satisfy simulator.js
-    for x in {201..203}; do
+    for x in {201..204}; do
         sudo ip a add 192.168.123.${x}/32 dev eth1
     done
     cp -v /vagrant/mqtt2kasa/tests/simulator.js.vagrant ./test/simulator.js

--- a/data/config.yaml.vagrant
+++ b/data/config.yaml.vagrant
@@ -27,3 +27,10 @@ locations:
         # alias: Mock HS110 thing3
         # this device has emeter capabilities
         emeter_poll_interval: 888
+    dimmer:
+        topic: /dimmer
+        host: 192.168.123.204
+        # alias: Mock HS220 thing4
+        # brightness can be changed on this device
+        emeter_poll_interval: 888
+

--- a/mqtt2kasa/events.py
+++ b/mqtt2kasa/events.py
@@ -39,6 +39,10 @@ class KasaStateEvent(BaseEvent):
         expected_attrs = "name", "state"
         super().__init__(expected_attrs, attrs)
 
+class KasaBrightnessEvent(BaseEvent):
+    def __init__(self, **attrs):
+        expected_attrs = "name", "brightness"
+        super().__init__(expected_attrs, attrs)
 
 class KasaEmeterEvent(BaseEvent):
     def __init__(self, **attrs):

--- a/mqtt2kasa/tests/basic_test.sh.vagrant
+++ b/mqtt2kasa/tests/basic_test.sh.vagrant
@@ -20,14 +20,16 @@ get_simulator_lines () {
 
 # restart service to trigger discovery
 sudo systemctl restart mqtt2kasa
-sleep 10
+sleep 20
 echo TEST: Check discovery
-get_log_lines 15
+get_log_lines 20
 grep --quiet -E 'Discovered 192\.168\.123\.201 .*thing1' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 grep --quiet -E 'Discovered 192\.168\.123\.202 .*thing2' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 grep --quiet -E 'Discovered 192\.168\.123\.203 .* thing3' ${TMP_OUTPUT} || \
+  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+grep --quiet -E 'Discovered 192\.168\.123\.204 .* thing4' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 
 echo TEST: EMeter
@@ -77,6 +79,18 @@ grep --quiet -E '192\.168\.123\.203' ${TMP_OUTPUT} || \
 grep --quiet -E '"err_code":0' ${TMP_OUTPUT} || \
   { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
 
+echo TEST: Check brightness
+mosquitto_pub -h ${MQTT_BROKER} -t /dimmer/brightness -m "77"
+get_log_lines
+grep --quiet -E 'Mqtt event causing device dimmer\(\/dimmer\/brightness\) to be set as 77' ${TMP_OUTPUT} || \
+  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+get_simulator_lines
+grep --quiet -E 'set_brightness.*"brightness": 77' ${TMP_OUTPUT} || \
+  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+grep --quiet -E '192\.168\.123\.204' ${TMP_OUTPUT} || \
+  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }
+grep --quiet -E 'set_brightness.*"err_code":0' ${TMP_OUTPUT} || \
+  { echo "FAILED in $0 line ${LINENO}" >&2; exit ${LINENO}; }  
 
 echo 'PASSED: Happy happy, joy joy!'
 rm -f ${TMP_OUTPUT}

--- a/mqtt2kasa/tests/simulator.js.vagrant
+++ b/mqtt2kasa/tests/simulator.js.vagrant
@@ -28,6 +28,14 @@ devices.push(
     data: { alias: 'Mock HS110 thing3', mac: '00:03:03:03:03:03', deviceId: 'thing3' },
   })
 );
+devices.push(
+  new Device({
+    port: 9999,
+    address: '192.168.123.204',
+    model: 'hs220',
+    data: { alias: 'Mock HS220 thing4', mac: '00:04:04:04:04:04', deviceId: 'thing4' },
+  })
+);
 
 devices.forEach((d) => {
   d.start();


### PR DESCRIPTION
The purpose of the PR is to introduce `\brightness` sub-topic to get and set brightness on dimmable devices (e.g. HS220). Discussion: https://github.com/flavio-fernandes/mqtt2kasa/issues/18

Unfortunately, I'm able to test this only with HS220 since I own those so I hope unit test coverage is enough to ensure that there are no breaking changes in devices that are not dimmable. 

`sudo journalctl -u mqtt2kasa.service --no-pager` output from unit tests:
```
May 12 01:34:30 mqtt2kasaVM systemd[1]: Started MQTT front end wrapper to python-kasa.
May 12 01:34:30 mqtt2kasaVM start_mqtt2kasa.sh[15729]: unfiltered_messages() is deprecated and will be removed in a future version. Use messages() instead.
May 12 01:34:30 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:30,457         mqtt:15 INFO     handle_mqtt_publish task started. Using retain:False and qos:0
May 12 01:34:30 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:30,813 kasa_wrapper:47 INFO     Discovered 192.168.123.201 alias:'Mock HS100 thing1' model:HS100(US) mac:00:01:01:01:01:01
May 12 01:34:35 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:35,940 kasa_wrapper:47 INFO     Discovered 192.168.123.202 alias:'Mock HS105 thing2' model:HS105(US) mac:00:02:02:02:02:02
May 12 01:34:35 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:35,961 kasa_wrapper:47 INFO     Discovered 192.168.123.203 alias:'Mock HS110 thing3' model:HS110(US) mac:00:03:03:03:03:03
May 12 01:34:35 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:35,985 kasa_wrapper:47 INFO     Discovered 192.168.123.204 alias:'Mock HS220 thing4' model:HS220(US) mac:00:04:04:04:04:04
May 12 01:34:35 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:35,991   keep_alive:81 INFO     No keep alives to monitor based on config: handle_keep_alives is done.
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,007         main:49 INFO     Kasa event requesting mqtt for bar to publish /kasa/device/bar as off
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,008         main:143 INFO     Mqtt event causing device bar to be set as off
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,010         main:49 INFO     Kasa event requesting mqtt for lar to publish /lar/switch as off
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,013         main:49 INFO     Kasa event requesting mqtt for dimmer to publish /dimmer as off
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,014 kasa_wrapper:248 INFO     bar has no emeter. no emeter polling is needed
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,017 kasa_wrapper:248 INFO     dimmer has no emeter. no emeter polling is needed
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,025         main:85 INFO     Kasa emeter event requesting mqtt for lar to publish /lar/switch/emeter as <EmeterStatus power=3.14 voltage=122.049119 current=0.1256 total=51.493>
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,029         main:66 INFO     Kasa event requesting mqtt for dimmer to publish /dimmer/brightness as 50
May 12 01:34:36 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:36,097         main:49 INFO     Kasa event requesting mqtt for foo to publish /foo as off
May 12 01:34:37 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:37,011         main:143 INFO     Mqtt event causing device lar to be set as off
May 12 01:34:38 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:38,014         main:143 INFO     Mqtt event causing device dimmer to be set as off
May 12 01:34:44 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:44,045         main:162 INFO     Mqtt event causing device dimmer(/dimmer/brightness) to be set as 50
May 12 01:34:45 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:45,047         main:143 INFO     Mqtt event causing device foo to be set as off
May 12 01:34:51 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:51,580         main:143 INFO     Mqtt event causing device foo to be set as off
May 12 01:34:52 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:52,799         main:143 INFO     Mqtt event causing device bar to be set as on
May 12 01:34:52 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:52,799 kasa_wrapper:301 INFO     bar changing state to on
May 12 01:34:54 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:54,019         main:143 INFO     Mqtt event causing device lar to be set as on
May 12 01:34:54 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:54,019 kasa_wrapper:301 INFO     lar changing state to on
May 12 01:34:55 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:55,241         main:143 INFO     Mqtt event causing device foo to be set as on
May 12 01:34:55 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:55,242 kasa_wrapper:301 INFO     foo changing state to on
May 12 01:34:57 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:57,709         main:143 INFO     Mqtt event causing device lar to be set as off
May 12 01:34:57 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:34:57,709 kasa_wrapper:301 INFO     lar changing state to off
May 12 01:35:00 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:35:00,166         main:162 INFO     Mqtt event causing device dimmer(/dimmer/brightness) to be set as 77
May 12 01:35:00 mqtt2kasaVM start_mqtt2kasa.sh[15729]: 2024-05-12 01:35:00,166 kasa_wrapper:316 INFO     dimmer changing brightness to 77
```