### PR TITLE
add dockerfile and flow

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,0 +1,40 @@
+name: Build and Publish Docker Image
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker Image Tag'
+        required: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3        
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/mqtt2kasa:${{ github.event.inputs.tag || github.event.release.tag_name }}
+          platforms: linux/amd64,linux/arm64
+          context: .
+
+      - name: Logout from DockerHub
+        run: docker logout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10.12-slim
+WORKDIR /usr/src/app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY mqtt2kasa/*.py mqtt2kasa/
+ENV PYTHONPATH=/usr/src/app
+CMD ["python3", "mqtt2kasa/main.py", "/data/config.yaml"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+services:
+  mqtt2kasa:
+    # uncomment to build using local Dockerfile
+    # build: 
+      # context: .
+      # dockerfile: Dockerfile
+    image: flavio-fernandes/mqtt2kasa
+    restart: unless-stopped
+    volumes:
+      - ./data:/data


### PR DESCRIPTION
The purpose of the PR is to introduce functionality to create multi-arch docker image. Docker image is an alternative way to run mqtt2kasa. 

The PR contains `Dockerfile` that is based of `python:3.10.12-slim` image. This image works with linux/amd64 linux/arm64 (e.g. Raspberry Pi4) architectures. I've tried using alpine image but I got an error during pip install related to cryptography lib. Unfortunately, I've tried to include arm/v7 to support Rasspberry Pi 1,2,3 and W but I get the same cryptography-related error. This can be a future improvement but linux/amd64 linux/arm64 should cover most modern boards.

Docker container expects `\data\config.yaml` to be mounted with a proper configuration file. an example of how it can be done is in the `docker-compose.yaml`. 

`.github/workflows/docker-build-publish.yml` action was added to automate docker image generation and publishing to docker hub. A few things has to be configured in repo settings to make this possible:
- an existing docker account has to be registered (it's free). @flavio-fernandes , I suggest it to be `flavio-fernandes` to make it consistent with the repo account. Let me know if you want it to be something else, I can update the PR. 
- a secret `DOCKER_USERNAME` has to be created in repo settings with the docker hub account name. Docs: https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository
- generate https://docs.docker.com/security/for-developers/access-tokens/#create-an-access-token and store it in secrets.DOCKER_TOKEN. Permissions should be `Read & Write`
Once DOCKER_USERNAME and DOCKER_TOKEN are created and set, the action should work.
The action is triggered:
- manually from the `Actions` tab. The flow expects one input named `tag`. I suggest it to be version, e.g. `0.0.3`. This will result in flavio-fernandes/mqtt2kasa:0.0.3 image creation. note, this will be available once the change is merged into main, `workflow_dispatch` are visible only for `mainl` branch in UI. This is ideal for testing and fixes.
- automatically when a new release is created. github tag will be used as an image `tag`.

Changes to the source code:
I had to update log.py to make sure that only console logs are output since `python:3.10.12-slim` doesn't support ["/run/systemd/journal/syslog", "/var/run/syslog", "/device/log"] and output logs to stdout is pretty much a standard :). I put an inline comment about a changes in behavior for the context. 

**Testing**
I tested the flow, docker image and the configuration in my repo - https://github.com/aderesh/mqtt2kasa and my docker hub account - https://hub.docker.com/repository/docker/aderesh/mqtt2kasa/general. Both manual and release flows were triggered. I also tested amd64 image on my laptop and arm64 on Raspberry PI 4. 
A sample log output:
```
pi@piz2w:~/iot-home $ docker logs 3213157e22b6
2024-05-12 21:32:58,676          log:32 INFO     Running in a Docker container. Logs are sent to stdout only
2024-05-12 21:32:58,676       config:138 INFO     loading yaml config file /data/config.yaml
unfiltered_messages() is deprecated and will be removed in a future version. Use messages() instead.
2024-05-12 21:32:58,704         mqtt:14 INFO     handle_mqtt_publish task started. Using retain:False and qos:0
2024-05-12 21:32:58,706   keep_alive:80 INFO     No keep alives to monitor based on config: handle_keep_alives is done.
2024-05-12 21:33:00,386 kasa_wrapper:45 INFO     Discovered 192.168.0.14 alias:'Kitchen' model:HS220(US) mac:1C:61:B4:7F:DF:EF
2024-05-12 21:33:00,418         main:47 INFO     Kasa event requesting mqtt for kitchen/lights to publish /kitchen/lights as off
2024-05-12 21:33:00,422         main:121 INFO     Mqtt event causing device kitchen/lights to be set as off
```


