### PR TITLE
[codex] Run unit tests in CI and Vagrant provisioning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,15 @@ jobs:
           echo ----
           sudo docker logs mqtt
 
+      - name: Run Unit Tests
+        run: |
+          sudo -u vagrant -i <<'EOF'
+          cd /vagrant
+          source /vagrant/env/bin/activate
+          pip install pytest
+          python -m pytest mqtt2kasa/tests/unit
+          EOF
+
       - name: Run Tests
         run: |
           sudo -u vagrant -i <<'EOF'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -87,6 +87,11 @@ $test_mqtt2kasa = <<SCRIPT
 # sudo systemctl restart tplink-smarthome-simulator.service
 sudo systemctl status --full --no-pager mqtt2kasa
 sleep 5  ; # give it a few secs for service to start
+pushd /vagrant
+source /vagrant/env/bin/activate
+pip install pytest
+python -m pytest mqtt2kasa/tests/unit
+popd
 ~/basic_test.sh
 SCRIPT
 


### PR DESCRIPTION
## Summary

Runs the Python unit test suite as part of both GitHub Actions and Vagrant provisioning.

## Changes

- Add a GitHub Actions step that installs pytest and runs `python -m pytest mqtt2kasa/tests/unit` before the integration script.
- Add the same unit-test step to the Vagrant provisioning path before `basic_test.sh`.

## Validation

- `ruby -c Vagrantfile`
- `git diff --check origin/main..HEAD`

This PR is intentionally separate from the device availability feature work.